### PR TITLE
feature: recursive DataFrame.derive()

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -441,18 +441,18 @@ toml = ["tomli"]
 
 [[package]]
 name = "cssutils"
-version = "2.7.1"
+version = "2.9.0"
 description = "A CSS Cascading Style Sheets library for Python"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "cssutils-2.7.1-py3-none-any.whl", hash = "sha256:1e92e0d9dab2ec8af9f38d715393964ba533dc3beacab9b072511dfc241db775"},
-    {file = "cssutils-2.7.1.tar.gz", hash = "sha256:340ecfd9835d21df8f98500f0dfcea0aee41cb4e19ecbc2cf94f0a6d36d7cb6c"},
+    {file = "cssutils-2.9.0-py3-none-any.whl", hash = "sha256:f8b013169e281c0c6083207366c5005f5dd4549055f7aba840384fb06a78745c"},
+    {file = "cssutils-2.9.0.tar.gz", hash = "sha256:89477b3d17d790e97b9fb4def708767061055795aae6f7c82ae32e967c9be4cd"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["cssselect", "importlib-resources", "jaraco.test (>=5.1)", "lxml", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["cssselect", "importlib-resources", "jaraco.test (>=5.1)", "lxml", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [[package]]
 name = "dict2css"

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -207,6 +207,7 @@ def test_derive_functionality():
         column_derived: int = pt.Field(derived_from="underived")
         expr_derived: int = pt.Field(derived_from=2 * pl.col("underived"))
         second_order_derived: int = pt.Field(derived_from=2 * pl.col("expr_derived"))
+        
 
     df = DerivedModel.DataFrame({"underived": [1, 2]})
     assert df.columns == ["underived"]
@@ -231,7 +232,32 @@ def test_derive_functionality():
         match=r"Can not derive dataframe column from type \<class 'type'\>\.",
     ):
         InvalidModel.DataFrame().derive()
+    
 
+def test_recursive_derive():
+    """Data.Frame.derive() infers proper derivation order and executes it, then returns columns in the order given by the model."""
+
+    class DerivedModel(pt.Model):
+        underived: int
+        const_derived: int = pt.Field(derived_from=pl.lit(3))
+        second_order_derived: int = pt.Field(derived_from=2 * pl.col("expr_derived"))  # requires expr_derived to be derived first
+        column_derived: int = pt.Field(derived_from="underived")
+        expr_derived: int = pt.Field(derived_from=2 * pl.col("underived"))
+    
+    df = DerivedModel.DataFrame({"underived": [1, 2]})
+    assert df.columns == ["underived"]
+    derived_df = df.derive()
+    
+    correct_derived_df = DerivedModel.DataFrame(
+        {
+            "underived": [1, 2],
+            "const_derived": [3, 3],
+            "second_order_derived": [4, 8],
+            "column_derived": [1, 2],
+            "expr_derived": [2, 4],  # derived before second_order_derived, but remains in last position in output df according to the model
+        }
+    )
+    assert derived_df.frame_equal(correct_derived_df)
 
 def test_drop_method():
     """We should be able to drop columns not specified by the data frame model."""


### PR DESCRIPTION
```
class Foo(pt.Model):
    bar: int = pt.Field(derived_from="foo")
    quad_bar: int = pt.Field(derived_from=2 * pl.col("double_bar"))
    double_bar: int = pt.Field(derived_from=2 * pl.col("bar"))
```
will derive double_bar first, then quad_bar, automatically detecting upstream dependencies and ensuring that execution order is correct. The data frame will be returned in the order specified by the model (quad_bar comes before double_bar).

Added new test_recursive_dependencies. 