### PR TITLE
feature: misc improvements

### DIFF
--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Type, Union, cast
+from typing import TYPE_CHECKING, Type, Union, cast, get_args, get_origin
 
 import polars as pl
-from typing_extensions import get_args, get_origin
 
 from patito.exceptions import (
     ColumnDTypeError,
@@ -150,7 +149,7 @@ def _find_errors(  # noqa: C901
         if not isinstance(dtype, pl.List):
             continue
 
-        annotation = schema.__annotations__[column]  # type: ignore[unreachable]
+        annotation = schema.model_fields[column].annotation  # type: ignore[unreachable]
 
         # Retrieve the annotation of the list itself,
         # dewrapping any potential Optional[...]


### PR DESCRIPTION
- drops `ModelMetaclass`, consolidates attributes into classproperties on `Model` (potentially useful [@classproperty implementation](https://github.com/pola-rs/polars/blob/a366bc9489debeb998361ccb2b586afe315332f9/py-polars/polars/datatypes/classes.py#L25) for future, unclear [if python will continue to support past 3.11](https://docs.python.org/3/whatsnew/3.11.html#language-builtins))
- implement `DataFrame.from_existing` for creation of patito data frames from pre-built polars data frames.
- create missing columns with `fill_null` if not provided by user and defaults are specified in model
- `derived_columns` property to track which columns can be created by applying expressions to other columns