### PR TITLE
fix: misc fixes

### DIFF
--- a/src/patito/exceptions.py
+++ b/src/patito/exceptions.py
@@ -127,7 +127,7 @@ ErrorList = Union[Sequence[Any], ErrorWrapper]
 class DataFrameValidationError(Representation, ValueError):
     __slots__ = "raw_errors", "model", "_error_cache"
 
-    def __init__(self, errors: Sequence[ErrorList], model: "BaseModel") -> None:
+    def __init__(self, errors: Sequence[ErrorList], model: Type["BaseModel"]) -> None:
         self.raw_errors = errors
         self.model = model
         self._error_cache: Optional[List["ErrorDict"]] = None

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -437,7 +437,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
 
     def _derive_column(
         self, df: "LDF", column_name: str, props: Mapping[str, Any]
-    ) -> Tuple["DF", Sequence[str]]:
+    ) -> Tuple["LDF", Sequence[str]]:
         props_col = props[column_name]
         if "derived_from" not in props_col:
             return df, []
@@ -702,7 +702,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
         return df.derive()  # TODO delegate derivations to user?
 
     @classmethod
-    def from_existing(cls, df: pl.DataFrame):
+    def from_existing(cls: Type[DF], df: pl.DataFrame) -> DF:
         """Constructs a patito.DataFrame object from an existing polars.DataFrame object"""
         return cls.model.DataFrame._from_pydf(df._df).cast()
 

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -20,6 +20,7 @@ from typing import (
     get_args,
     Sequence,
     Tuple,
+    Mapping,
 )
 
 import polars as pl
@@ -85,9 +86,9 @@ PL_INTEGER_DTYPES = [
 ]
 
 
-def contains_object(dtype: pl.DataType) -> bool:
+def contains_object(dtype: PolarsDataType) -> bool:
     try:
-        inner = dtype.inner
+        inner = dtype.inner  # pyright: ignore
         if inner == pl.Object():
             return True
         else:
@@ -96,8 +97,17 @@ def contains_object(dtype: pl.DataType) -> bool:
         return False
 
 
-class Model(BaseModel):
+class ModelMetaclass(
+    PydanticModelMetaclass
+):  # keep around for typing on Model construction
+    ...
+
+
+class Model(BaseModel, metaclass=ModelMetaclass):
     """Custom pydantic class for representing table schema and constructing rows."""
+
+    if TYPE_CHECKING:
+        model_fields: ClassVar[Dict[str, FieldInfo]]
 
     @classmethod
     @property
@@ -123,7 +133,7 @@ class Model(BaseModel):
     @property
     def dtypes(  # type: ignore
         cls: Type[ModelType],  # pyright: ignore
-    ) -> dict[str, Type[pl.DataType]]:
+    ) -> dict[str, PolarsDataType]:
         """
         Return the polars dtypes of the dataframe.
 
@@ -151,7 +161,7 @@ class Model(BaseModel):
     @property
     def valid_dtypes(  # type: ignore
         cls: Type[ModelType],  # pyright: ignore
-    ) -> dict[str, List[Union[pl.PolarsDataType, pl.List]]]:
+    ) -> dict[str, List[Union[PolarsDataType, pl.List]]]:
         """
         Return a list of polars dtypes which Patito considers valid for each field.
 
@@ -195,10 +205,10 @@ class Model(BaseModel):
 
     @classmethod
     def _valid_dtypes(  # noqa: C901
-        cls: Type[ModelType],
+        cls: Type[ModelType],  # pyright: ignore
         column: str,
         props: Dict,
-    ) -> Optional[List[pl.PolarsDataType]]:
+    ) -> Optional[List[PolarsDataType]]:
         """
         Map schema property to list of valid polars data types.
 
@@ -247,7 +257,7 @@ class Model(BaseModel):
     @staticmethod
     def _pydantic_type_to_valid_polars_types(
         props: Dict,
-    ) -> Optional[List[pl.DataType]]:
+    ) -> Optional[List[PolarsDataType]]:
         if props["type"] == "integer":
             return PL_INTEGER_DTYPES
         elif props["type"] == "number":
@@ -744,7 +754,7 @@ class Model(BaseModel):
         cls,
         field: Optional[str] = None,
         properties: Optional[Dict[str, Any]] = None,
-    ) -> Union[date, datetime, float, int, str, None]:
+    ) -> Union[date, datetime, float, int, str, None, Mapping, List]:
         """
         Return a valid example value for the given model field.
 
@@ -783,6 +793,7 @@ class Model(BaseModel):
             )
         if field:
             properties = cls._schema_properties()[field]
+        properties = properties or {}
 
         if "type" in properties:
             field_type = properties["type"]
@@ -1433,7 +1444,7 @@ class Model(BaseModel):
             pass
 
     @classmethod
-    def _schema_properties(cls):
+    def _schema_properties(cls) -> Dict[str, Any]:
         schema = cls.schema()
         return cls.schema()["properties"]
 
@@ -1532,8 +1543,13 @@ class Model(BaseModel):
             if x in field.__slots__ and x not in ["annotation", "default"]
         }
         if make_nullable:
-            # This originally non-nullable field has become nullable
-            field_type = Optional[field_type]
+            if field_type is None:
+                raise TypeError(
+                    "Cannot make field nullable if no type annotation is provided!"
+                )
+            else:
+                # This originally non-nullable field has become nullable
+                field_type = Optional[field_type]
         elif field.is_required() and default is None:
             # We need to replace Pydantic's None default value with ... in order
             # to make it clear that the field is still non-nullable and
@@ -1578,10 +1594,10 @@ class FieldInfo(fields.FieldInfo):
         )
 
 
-def Field(
+def Field(  # noqa: C901
     *args,
     **kwargs,
-):
+) -> Any:
     pt_kwargs = {k: kwargs.pop(k, None) for k in get_args(PT_INFO)}
     meta_kwargs = {
         k: v for k, v in kwargs.items() if k in fields.FieldInfo.metadata_lookup

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -216,7 +216,8 @@ class Model(BaseModel):
                     f"No valid dtype mapping found for column '{column}'."
                 )
             return [pl.List(dtype) for dtype in item_dtypes]
-        if "dtype" in props:
+
+        if "dtype" in props and "anyOf" not in props:
             return [
                 props["dtype"],
             ]
@@ -1454,15 +1455,6 @@ class Model(BaseModel):
                 field_name,
                 model_schema,
             )
-        if "anyOf" in field_info:
-            field["anyOf"] = [
-                cls._append_field_info_to_props(
-                    f,
-                    field_name,
-                    model_schema,
-                )
-                for f in field_info["anyOf"]
-            ]
         if required is not None:
             field["required"] = required
         if "const" in field_info and "type" not in field_info:

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -145,30 +145,30 @@ def test_nested_models():
     class NestedModel(pt.Model):
         nested_field: int
 
-    class ParentModel(pt.Model):
+    class ParentModel1(pt.Model):
         parent_field: int
         nested_model: NestedModel
 
-    example_model = ParentModel.example()
+    example_model = ParentModel1.example()
     with pytest.raises(NotImplementedError):
-        example_df = ParentModel.examples()
+        example_df = ParentModel1.examples()
     assert isinstance(example_model.nested_model, NestedModel)
     assert example_model.nested_model.nested_field is not None
 
     # inheritance also works
-    class ParentModel(NestedModel):
+    class ParentModel2(NestedModel):
         parent_field: int
 
-    example_model = ParentModel.example()
+    example_model = ParentModel2.example()
     assert example_model.nested_field is not None
     assert example_model.parent_field is not None
 
     # and optional nested models are ok
-    class ParentModel(pt.Model):
+    class ParentModel3(pt.Model):
         parent_field: int
         nested_model: Optional[NestedModel] = None
 
-    example_model = ParentModel.example()
+    example_model = ParentModel3.example()
     assert example_model.nested_model is None
 
     # sequences of nested models also work

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -495,10 +495,10 @@ def test_model_schema():
     assert schema["properties"]["a"]["type"] == "integer"
     assert not schema["properties"]["c"]["required"]
 
-    class ParentModel(pt.Model):
-        parent_field: int
-        nested_models: Optional[Sequence[Model]] = None
 
-    valid_dtypes = ParentModel.valid_dtypes
-    assert valid_dtypes["parent_field"] == PL_INTEGER_DTYPES
-    assert set(valid_dtypes["nested_models"]) == set([pl.List(pl.Object), pl.Null])
+def test_nullable_columns():
+    class Test(pt.Model):
+        foo: str | None = pt.Field(dtype=pl.Utf8)
+
+    assert Test.nullable_columns == {"foo"}
+    assert set(Test.valid_dtypes["foo"]) == {pl.Utf8, pl.Null}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -505,14 +505,14 @@ def test_nullable_columns():
 
 
 def test_conflicting_type_dtype():
-    class Test(pt.Model):
+    class Test1(pt.Model):
         foo: int = pt.Field(dtype=pl.Utf8)
 
     with pytest.raises(ValueError):
-        Test.valid_dtypes()
+        Test1.valid_dtypes
 
-    class Test(pt.Model):
+    class Test2(pt.Model):
         foo: str = pt.Field(dtype=pl.Float32)
 
     with pytest.raises(ValueError):
-        Test.valid_dtypes()
+        Test2.valid_dtypes

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -502,3 +502,17 @@ def test_nullable_columns():
 
     assert Test.nullable_columns == {"foo"}
     assert set(Test.valid_dtypes["foo"]) == {pl.Utf8, pl.Null}
+
+
+def test_conflicting_type_dtype():
+    class Test(pt.Model):
+        foo: int = pt.Field(dtype=pl.Utf8)
+
+    with pytest.raises(ValueError):
+        Test.valid_dtypes()
+
+    class Test(pt.Model):
+        foo: str = pt.Field(dtype=pl.Float32)
+
+    with pytest.raises(ValueError):
+        Test.valid_dtypes()


### PR DESCRIPTION
- handle multiple annotations (e.g. `str | None`) when `dtype` is present in `FieldInfo`
- add checks that specified `dtype` is permissible under valid dtypes for annotation
- improved typing
- grab constraints nested in `anyOf` field in field `properties` to enforce on data frame validation